### PR TITLE
Deleted is_mutually_disjoint() and has_touching_boundaries()

### DIFF
--- a/Time_Set.py
+++ b/Time_Set.py
@@ -128,25 +128,6 @@ class Time_Set:
 
         return Time_Set(union)
 
-    def has_touching_boundaries(self):
-        """Determines if the set has intervals that share boundaries, but don't overlap.
-        
-        This is mainly a helper method for compute_union.
-        """
-        for ix, i in enumerate(self.time_intervals):
-            for j in self.time_intervals[0:ix] + self.time_intervals[ix + 1 :]:
-                if i.start == j.end or j.start == i.end:
-                    return True
-        return False
-
-    def is_mutually_disjoint(self) -> bool:
-        """Tells if the Time_Intervals in this Time_Set are mutually disjoint."""
-        for ix, i in enumerate(self.time_intervals):
-            for j in self.time_intervals[ix + 1 :]:
-                if not i.is_disjoint_with(j):
-                    return False
-        return True
-
 
 class Time_Interval:
     """A class that models time intervals.

--- a/test_Time_Set.py
+++ b/test_Time_Set.py
@@ -40,19 +40,6 @@ class Test_Time_Set(unittest.TestCase):
         self.assertEqual(Time_Set_1, Time_Set_2)
         self.assertNotEqual(Time_Set_1, Time_Set_3)
 
-    def test_is_mutually_disjoint(self):
-        """Test the is_mutally_disjoint() method."""
-        # totally disjoint.
-        self.assertTrue(Time_Set([tr1, tr4]).is_mutually_disjoint())
-        # share endpoint, but are disjoint.
-        self.assertTrue(Time_Set([tr1, tr3]).is_mutually_disjoint())
-        # overlapping intervals.
-        self.assertFalse(Time_Set([tr1, tr2]).is_mutually_disjoint())
-        # nested intervals.
-        self.assertFalse(Time_Set([tr4, tr5]).is_mutually_disjoint())
-        # nested, but first interval is disjoint with the rest.
-        self.assertFalse(Time_Set([tr1, tr4, tr5]).is_mutually_disjoint())
-
     def test_compute_intersection(self):
         """Tests the compute_intersection() method."""
         # standard compute_intersection().
@@ -106,18 +93,3 @@ class Test_Time_Set(unittest.TestCase):
                 [Time_Interval.from_strings("8/1/2022 7:00", "8/1/2022 10:00"), tr5]
             ),
         )
-
-    def test_has_touching_boundaries(self):
-        """Tests the has_touching_boundaries() method."""
-        # False by definition
-        self.assertFalse(Time_Set([]).has_touching_boundaries())
-        self.assertFalse(Time_Set([tr1]).has_touching_boundaries())
-        # False because compute_intersection() is not empty.
-        self.assertFalse(Time_Set([tr1, tr2]).has_touching_boundaries())
-        # False because disjoint and don't share boundary.
-        self.assertFalse(Time_Set([tr1, tr4]).has_touching_boundaries())
-        # True because all time intervals have touching boundaries.
-        self.assertTrue(Time_Set([tr1, tr13, tr4]).has_touching_boundaries())
-        # True because it has one touching boundary.
-        self.assertTrue(Time_Set([tr1, tr2, tr4]).has_touching_boundaries())
-


### PR DESCRIPTION
Deleted two methods: is_mutually_disjoint() and has_touching_boundaries(). They were mainly helper methods to the previous version of compute_union() that no longer requires them, so to clean up the idea of Time_Set, they are being deleted.